### PR TITLE
Fix #19, add test case

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -705,7 +705,6 @@ class Builder {
         clone._lastMethodType = this._lastMethodType
         clone._group = this._group
         clone._captureNames = Array.from(this._captureNames)
-        clone._implodeString = this.implodeString
 
         return clone
     }

--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -704,6 +704,8 @@ class Builder {
         clone._modifiers = this._modifiers
         clone._lastMethodType = this._lastMethodType
         clone._group = this._group
+        clone._captureNames = Array.from(this._captureNames)
+        clone._implodeString = this.implodeString
 
         return clone
     }

--- a/test/builder-test.js
+++ b/test/builder-test.js
@@ -178,4 +178,18 @@ describe('Builder isMatching', () => {
 
         assert.deepEqual(regex, /(?:foo)/)
     })
+
+    it('Stores named captures', () => {
+        const regex_new = new SRL("capture (anything once or more) as first");
+        const testcase = 'hello world';
+
+        let matches_new = regex_new.getMatch(testcase)
+        assert.equal(matches_new["first"], 'hello world')
+
+        const regex_cached = new SRL("capture (anything once or more) as first");
+
+        let matches_cached = regex_cached.getMatch(testcase)
+        assert.equal(matches_cached["first"], 'hello world')
+
+    })
 })

--- a/test/builder-test.js
+++ b/test/builder-test.js
@@ -192,4 +192,18 @@ describe('Builder isMatching', () => {
         assert.equal(matches_cached["first"], 'hello world')
 
     })
+    it('Stores named captures with implodeString', () => {
+	const query = "begin with literally 'hello '\ncapture (anything once or more) as first";
+        const regex_new = new SRL(query);
+        const testcase = 'hello world';
+
+        let matches_new = regex_new.getMatch(testcase)
+        assert.equal(matches_new["first"], 'world')
+
+        const regex_cached = new SRL(query);
+
+        let matches_cached = regex_cached.getMatch(testcase)
+        assert.equal(matches_cached["first"], 'world')
+
+    })
 })


### PR DESCRIPTION
This PR fixes #19.
I Modified the clone method so that it also copies the fields `_captureNames` and `_implodeString`. If it does not make sense to add the `_implodeString` field feel free to remove it. I just looked at the code briefly in order to resolve #19 as I ran into the same problem myself and needed it to be fixed.